### PR TITLE
Making things work on OS X

### DIFF
--- a/SuperCollider.py
+++ b/SuperCollider.py
@@ -123,7 +123,7 @@ class Sc_hide_consoleCommand(sublime_plugin.WindowCommand):
 class Sc_stop_all_soundsCommand(sublime_plugin.WindowCommand):
     def run(self):
         if Sc_startCommand.sclang_thread is not None and Sc_startCommand.sclang_thread.isAlive():
-            Sc_startCommand.sclang_process.stdin.write("thisProcess.stop;\x0c")
+            Sc_startCommand.sclang_process.stdin.write("thisProcess.stop;\n\x0c")
             Sc_startCommand.sclang_process.stdin.flush()
 
 # search for help on current word on SCCode.org


### PR DESCRIPTION
I had to add this character to the output of stop_all_sounds to get things to work on OS X. But, I should point out, things are working on OS X and that's awesome.
