### PR TITLE
Enable keyboard shortcuts for line and block comments

### DIFF
--- a/Comments (SuperCollider).tmPreferences
+++ b/Comments (SuperCollider).tmPreferences
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>name</key>
+        <string>Comments</string>
+        <key>scope</key>
+        <string>source.supercollider</string>
+        <key>settings</key>
+        <dict>
+            <key>shellVariables</key>
+            <array>
+                <dict>
+                    <key>name</key>
+                    <string>TM_COMMENT_START</string>
+                    <key>value</key>
+                    <string>// </string>
+                </dict>
+                <dict>
+                    <key>name</key>
+                    <string>TM_COMMENT_START_2</string>
+                    <key>value</key>
+                    <string>/*</string>
+                </dict>
+                <dict>
+                    <key>name</key>
+                    <string>TM_COMMENT_END_2</string>
+                    <key>value</key>
+                    <string>*/</string>
+                </dict>
+            </array>
+        </dict>
+    </dict>
+</plist>


### PR DESCRIPTION
I added a tmPreferences file to allow for commenting via keyboard shortcuts. For folks out there like me still using Sublime Text 2 :stuck_out_tongue: 

Closes #6 
